### PR TITLE
Реализован публичный контроллер CategoryPublicController и бизнес-логика для работы с его эндпоинтами

### DIFF
--- a/main-svc/pom.xml
+++ b/main-svc/pom.xml
@@ -28,6 +28,10 @@
             <artifactId>client</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/main-svc/pom.xml
+++ b/main-svc/pom.xml
@@ -34,4 +34,33 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.5.5.Final</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>
+                            -Amapstruct.defaultComponentModel=spring
+                        </arg>
+                        <arg>
+                            -Amapstruct.unmappedTargetPolicy=IGNORE
+                        </arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/main-svc/pom.xml
+++ b/main-svc/pom.xml
@@ -31,36 +31,14 @@
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
+            <version>1.5.5.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>1.5.5.Final</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.mapstruct</groupId>
-                            <artifactId>mapstruct-processor</artifactId>
-                            <version>1.5.5.Final</version>
-                        </path>
-                    </annotationProcessorPaths>
-                    <compilerArgs>
-                        <arg>
-                            -Amapstruct.defaultComponentModel=spring
-                        </arg>
-                        <arg>
-                            -Amapstruct.unmappedTargetPolicy=IGNORE
-                        </arg>
-                    </compilerArgs>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/main-svc/src/main/java/ru/practicum/controller/publics/CategoryPublicController.java
+++ b/main-svc/src/main/java/ru/practicum/controller/publics/CategoryPublicController.java
@@ -1,0 +1,43 @@
+package ru.practicum.controller.publics;
+
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import ru.practicum.dto.category.CategoryDto;
+import ru.practicum.service.category.CategoryService;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/categories")
+public class CategoryPublicController {
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public List<CategoryDto> getAllCategories(
+            @PositiveOrZero @RequestParam(defaultValue = "0") Integer from,
+            @Positive @RequestParam(defaultValue = "10") Integer size) {
+        log.info("В контроллер пришёл запрос на получение списка категорий");
+        log.info("Параметры строки запроса: from={}, size={}", from, size);
+        List<CategoryDto> categoryDtos = categoryService.getAllCategories(from, size);
+        log.info("Возвращаем список категорий клиенту. Размер списка: {}", categoryDtos.size());
+        return categoryDtos;
+    }
+
+    @GetMapping("/{catId}")
+    public CategoryDto getCategoryById(@PositiveOrZero @PathVariable Long catId) {
+        log.info("В контроллер пришёл запрос на получение категории");
+        log.info("Id запрашиваемой категории: {}", catId);
+        CategoryDto categoryDto = categoryService.getCategoryById(catId);
+        log.info("Возвращаем категорию клиенту");
+        return null;
+    }
+}

--- a/main-svc/src/main/java/ru/practicum/exceptions/NotFoundException.java
+++ b/main-svc/src/main/java/ru/practicum/exceptions/NotFoundException.java
@@ -1,0 +1,7 @@
+package ru.practicum.exceptions;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/main-svc/src/main/java/ru/practicum/mapper/CategoryMapper.java
+++ b/main-svc/src/main/java/ru/practicum/mapper/CategoryMapper.java
@@ -1,0 +1,10 @@
+package ru.practicum.mapper;
+
+import org.mapstruct.Mapper;
+import ru.practicum.dto.category.CategoryDto;
+import ru.practicum.model.Category;
+
+@Mapper(componentModel = "spring")
+public interface CategoryMapper {
+    CategoryDto toCategoryDto(Category category);
+}

--- a/main-svc/src/main/java/ru/practicum/service/category/CategoryService.java
+++ b/main-svc/src/main/java/ru/practicum/service/category/CategoryService.java
@@ -1,0 +1,13 @@
+package ru.practicum.service.category;
+
+import ru.practicum.dto.category.CategoryDto;
+
+import java.util.List;
+
+public interface CategoryService {
+
+    List<CategoryDto> getAllCategories(Integer from, Integer size);
+
+    CategoryDto getCategoryById(Long id);
+
+}

--- a/main-svc/src/main/java/ru/practicum/service/category/CategoryServiceImpl.java
+++ b/main-svc/src/main/java/ru/practicum/service/category/CategoryServiceImpl.java
@@ -1,0 +1,42 @@
+package ru.practicum.service.category;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import ru.practicum.dto.category.CategoryDto;
+import ru.practicum.exceptions.NotFoundException;
+import ru.practicum.mapper.CategoryMapper;
+import ru.practicum.model.Category;
+import ru.practicum.repository.CategoryRepository;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService {
+    private final CategoryRepository categoryRepository;
+    private final CategoryMapper categoryMapper;
+
+    @Override
+    public List<CategoryDto> getAllCategories(Integer from, Integer size) {
+        log.info("Сервис получил запрос на получение списка категорий");
+        PageRequest pageRequest = PageRequest.of(from, size);
+        List<CategoryDto> categories = categoryRepository.findAll(pageRequest)
+                .stream()
+                .map(categoryMapper::toCategoryDto)
+                .toList();
+        log.info("Список категорий вернулся из БД");
+        return categories;
+    }
+
+    @Override
+    public CategoryDto getCategoryById(Long id) {
+        log.info("Сервис получил запрос на получение категории");
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Категории с id " + id + "нет в БД"));
+        log.info("Категория получена из БД и передаётся в контроллер");
+        return categoryMapper.toCategoryDto(category);
+    }
+}


### PR DESCRIPTION
- В модуле main-svc создан пакет controller с тремя подпакетами: admin, privates и publics.

- В подпакете publics реализован контроллер CategoryPublicController с двумя эндпоинтами, по которым неавторизованные пользователи могут запрашивать данные о конкретной категории или о категориях в целом.

- Дополнительно созданы пакеты mapper и service с подпакетом category.

- В подпакете category пакета service созданы интерфейс CategoryService и реализующий его класс CategoryServiceImpl.

- В пакете mapper создан интерфейс CategoryMapper, который маппит сущность Category в CategoryDto. 