### PR TITLE
Смёрджить ветку main_svc_compilation_public_controller в ветку main_svc

### DIFF
--- a/main-svc/src/main/java/ru/practicum/controller/publics/CategoryPublicController.java
+++ b/main-svc/src/main/java/ru/practicum/controller/publics/CategoryPublicController.java
@@ -38,6 +38,6 @@ public class CategoryPublicController {
         log.info("Id запрашиваемой категории: {}", catId);
         CategoryDto categoryDto = categoryService.getCategoryById(catId);
         log.info("Возвращаем категорию клиенту");
-        return null;
+        return categoryDto;
     }
 }

--- a/main-svc/src/main/java/ru/practicum/controller/publics/CompilationPublicController.java
+++ b/main-svc/src/main/java/ru/practicum/controller/publics/CompilationPublicController.java
@@ -1,0 +1,43 @@
+package ru.practicum.controller.publics;
+
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import ru.practicum.dto.compilation.CompilationDto;
+import ru.practicum.service.compilation.CompilationService;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/compilations")
+public class CompilationPublicController {
+    private final CompilationService compilationService;
+
+    @GetMapping
+    public List<CompilationDto> getAllCompilations(
+            @RequestParam(required = false) Boolean pinned,
+            @RequestParam(defaultValue = "0") Integer from,
+            @RequestParam(defaultValue = "10") Integer size) {
+        log.info("В контроллер пришёл запрос на получение списка подборок");
+        log.info("Параметры строки запроса: pinned={}, from={}, size={}", pinned, from, size);
+        List<CompilationDto> compilationDtos = compilationService.getAllCompilations(pinned, from, size);
+        log.info("Возвращаем список подборок клиенту. Размер списка: {}", compilationDtos.size());
+        return compilationDtos;
+    }
+
+    @GetMapping("/{compId}")
+    public CompilationDto getCompilationById(@PositiveOrZero @PathVariable Long compId) {
+        log.info("В контроллер пришёл запрос на получение подборки");
+        log.info("Id запрашиваемой подборки: {}", compId);
+        CompilationDto compilationDto = compilationService.getCompilationById(compId);
+        log.info("Возвращаем подборку клиенту");
+        return compilationDto;
+    }
+}

--- a/main-svc/src/main/java/ru/practicum/mapper/CompilationMapper.java
+++ b/main-svc/src/main/java/ru/practicum/mapper/CompilationMapper.java
@@ -1,0 +1,12 @@
+package ru.practicum.mapper;
+
+import org.mapstruct.Mapper;
+import ru.practicum.dto.compilation.CompilationDto;
+import ru.practicum.model.Compilation;
+
+@Mapper(componentModel = "spring")
+public interface CompilationMapper {
+    // Здесь пока не маппится множество с сущностями Event,
+    // для этого нужно создать маппер EventMapper, мапящий Event в EventShortDto
+    CompilationDto toCompilationDto(Compilation compilation);
+}

--- a/main-svc/src/main/java/ru/practicum/repository/CompilationRepository.java
+++ b/main-svc/src/main/java/ru/practicum/repository/CompilationRepository.java
@@ -1,7 +1,13 @@
 package ru.practicum.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import ru.practicum.model.Compilation;
 
+import java.util.List;
+
 public interface CompilationRepository extends JpaRepository<Compilation, Long> {
+
+    List<Compilation> findAllByPinned(Boolean pinned, Pageable pageable);
+
 }

--- a/main-svc/src/main/java/ru/practicum/service/category/CategoryServiceImpl.java
+++ b/main-svc/src/main/java/ru/practicum/service/category/CategoryServiceImpl.java
@@ -35,7 +35,7 @@ public class CategoryServiceImpl implements CategoryService {
     public CategoryDto getCategoryById(Long id) {
         log.info("Сервис получил запрос на получение категории");
         Category category = categoryRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("Категории с id " + id + "нет в БД"));
+                .orElseThrow(() -> new NotFoundException("Категории с id " + id + " нет в БД"));
         log.info("Категория получена из БД и передаётся в контроллер");
         return categoryMapper.toCategoryDto(category);
     }

--- a/main-svc/src/main/java/ru/practicum/service/compilation/CompilationService.java
+++ b/main-svc/src/main/java/ru/practicum/service/compilation/CompilationService.java
@@ -1,0 +1,13 @@
+package ru.practicum.service.compilation;
+
+import ru.practicum.dto.compilation.CompilationDto;
+
+import java.util.List;
+
+public interface CompilationService {
+
+    List<CompilationDto> getAllCompilations(Boolean pinned, Integer from, Integer size);
+
+    CompilationDto getCompilationById(Long compId);
+
+}

--- a/main-svc/src/main/java/ru/practicum/service/compilation/CompilationServiceImpl.java
+++ b/main-svc/src/main/java/ru/practicum/service/compilation/CompilationServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import ru.practicum.dto.compilation.CompilationDto;
+import ru.practicum.mapper.CompilationMapper;
 import ru.practicum.repository.CompilationRepository;
 
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CompilationServiceImpl implements CompilationService {
     private final CompilationRepository compilationRepository;
+    private final CompilationMapper compilationMapper;
 
     @Override
     public List<CompilationDto> getAllCompilations(Boolean pinned, Integer from, Integer size) {

--- a/main-svc/src/main/java/ru/practicum/service/compilation/CompilationServiceImpl.java
+++ b/main-svc/src/main/java/ru/practicum/service/compilation/CompilationServiceImpl.java
@@ -5,7 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import ru.practicum.dto.compilation.CompilationDto;
+import ru.practicum.exceptions.NotFoundException;
 import ru.practicum.mapper.CompilationMapper;
+import ru.practicum.model.Compilation;
 import ru.practicum.repository.CompilationRepository;
 
 import java.util.List;
@@ -38,7 +40,10 @@ public class CompilationServiceImpl implements CompilationService {
 
     @Override
     public CompilationDto getCompilationById(Long compId) {
-        log.info("");
-        return null;
+        log.info("Сервис получил запрос на получение подборки");
+        Compilation compilation = compilationRepository.findById(compId)
+                .orElseThrow(() -> new NotFoundException("Подборки с id " + compId + " нет в БД"));
+        log.info("Подборка получена из БД и передаётся в контроллер");
+        return compilationMapper.toCompilationDto(compilation);
     }
 }

--- a/main-svc/src/main/java/ru/practicum/service/compilation/CompilationServiceImpl.java
+++ b/main-svc/src/main/java/ru/practicum/service/compilation/CompilationServiceImpl.java
@@ -2,6 +2,7 @@ package ru.practicum.service.compilation;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import ru.practicum.dto.compilation.CompilationDto;
 import ru.practicum.mapper.CompilationMapper;
@@ -18,11 +19,26 @@ public class CompilationServiceImpl implements CompilationService {
 
     @Override
     public List<CompilationDto> getAllCompilations(Boolean pinned, Integer from, Integer size) {
-        return List.of();
+        log.info("Сервис получил запрос на получение списка подборок");
+        PageRequest pageRequest = PageRequest.of(from, size);
+        if (pinned != null) {
+            log.info("Получаем из БД подборки, у которых поле pinned={}", pinned);
+            return compilationRepository.findAllByPinned(pinned, pageRequest)
+                    .stream()
+                    .map(compilationMapper::toCompilationDto)
+                    .toList();
+        } else {
+            log.info("Получаем из БД все подборки");
+            return compilationRepository.findAll(pageRequest)
+                    .stream()
+                    .map(compilationMapper::toCompilationDto)
+                    .toList();
+        }
     }
 
     @Override
     public CompilationDto getCompilationById(Long compId) {
+        log.info("");
         return null;
     }
 }

--- a/main-svc/src/main/java/ru/practicum/service/compilation/CompilationServiceImpl.java
+++ b/main-svc/src/main/java/ru/practicum/service/compilation/CompilationServiceImpl.java
@@ -1,0 +1,26 @@
+package ru.practicum.service.compilation;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import ru.practicum.dto.compilation.CompilationDto;
+import ru.practicum.repository.CompilationRepository;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CompilationServiceImpl implements CompilationService {
+    private final CompilationRepository compilationRepository;
+
+    @Override
+    public List<CompilationDto> getAllCompilations(Boolean pinned, Integer from, Integer size) {
+        return List.of();
+    }
+
+    @Override
+    public CompilationDto getCompilationById(Long compId) {
+        return null;
+    }
+}


### PR DESCRIPTION
- В пакет публичных контроллеров добавил контроллер **CompilationPublicController**, через который неавторизованные юзеры могут запрашивать список подборок или смотреть подборку с конкретным id.

- В контроллер **CompilationPublicController** добавил зависимость-абстракцию **CompilationService.**

- Интерфейс **CompilationService** реализует класс **CompilationServiceImpl**, в котором объявлены и реализованы методы `getAllCompilations(Boolean pinned, Integer from, Integer size)` (возвращает список подборок согласно параметрам фильтрации) и `getCompilationById(Long id)` (возвращает конкретную подборку).

- В репозитории **CompilationRepository** объявлен запросный метод `getAllByPinned(Boolean pinned, Pageable pageable)`, который ищет в БД подборки по значению поля pinned.

- Создан маппер **CompilationMapper** для маппинга сущности Compilation в **CompilationDto**. 